### PR TITLE
Use server settings templates for workspaces & authenticate from tray

### DIFF
--- a/client/ayon_perforce/addon.py
+++ b/client/ayon_perforce/addon.py
@@ -58,8 +58,8 @@ class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
     def get_connection_info(
         self,
         project_name: str,
-        task_entity: dict,  # use ayon type hint
-        folder_entity: dict,  # use ayon type hint
+        task_entity: dict,
+        folder_entity: dict,
         folder_path: str,
         project_settings: Optional[dict] = None,
     ) -> ConnectionInfo:

--- a/client/ayon_perforce/addon.py
+++ b/client/ayon_perforce/addon.py
@@ -12,6 +12,7 @@ from ayon_core.pipeline.template_data import get_template_data_with_names
 from ayon_core.settings import get_project_settings
 
 from .version import __version__
+from .tray.login import PerforceLoginTray
 
 
 PERFORCE_ADDON_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -44,6 +45,7 @@ class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
     name = "perforce"
     version = __version__
     webserver = None
+    login_tray = None
 
     # Public Methods:
     def initialize(self, settings: dict[str, Any]) -> None:
@@ -120,6 +122,7 @@ class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
 
     def tray_init(self) -> None:
         """Called when the tray is initializing."""
+        self.login_tray = PerforceLoginTray(self)
 
     def get_plugin_paths(self) -> dict[str, list[str]]:  # noqa: PLR6301
         """Called to get the plugin paths.
@@ -145,6 +148,16 @@ class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
             from ayon_perforce.backend.communication_server import WebServer
             self.webserver = WebServer()
             self.webserver.start()
+
+    def tray_menu(self, tray_menu: dict[str, Any]) -> None:
+        """Add Perforce menu to the tray.
+
+        Args:
+            tray_menu (dict[str, Any]): Tray menu.
+
+        """
+        if self.enabled:
+            self.login_tray.tray_menu(tray_menu)
 
     # PLR6301: This method is defined by the interface
     def get_create_plugin_paths(  # noqa: PLR6301

--- a/client/ayon_perforce/addon.py
+++ b/client/ayon_perforce/addon.py
@@ -50,9 +50,9 @@ class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
     # Public Methods:
     def initialize(self, settings: dict[str, Any]) -> None:
         """Initialize the addon."""
-        vc_settings: dict[str, Any] = settings.get(self.name)
-        enabled: bool = vc_settings and vc_settings["enabled"]
-        self.set_service_running_icon() if enabled else self.set_service_failed_icon()  # noqa: E501
+        self.settings: dict[str, Any] = settings.get(self.name)
+        self.enabled: bool = self.settings and self.settings["enabled"]
+        self.set_service_running_icon() if self.enabled else self.set_service_failed_icon()  # noqa: E501
 
     def get_connection_info(
         self,

--- a/client/ayon_perforce/addon.py
+++ b/client/ayon_perforce/addon.py
@@ -101,6 +101,18 @@ class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
             workspace_name=ws_name
         )
 
+    def get_server_url(self, project_settings: Optional[dict] = None) -> str:
+        """Get Perforce server URL.
+
+        Returns:
+            str: Perforce server URL.
+
+        """
+        if project_settings:
+            self.settings = project_settings["perforce"]
+
+        return f"{self.settings['host_name']}:{self.settings['port']}"
+
     @staticmethod
     def sync_to_version(
             conn_info: ConnectionInfo, change_id: int) -> None:

--- a/client/ayon_perforce/addon.py
+++ b/client/ayon_perforce/addon.py
@@ -12,6 +12,7 @@ from ayon_core.pipeline.template_data import get_template_data_with_names
 from ayon_core.settings import get_project_settings
 
 from .version import __version__
+from .lib import get_local_login
 from .tray.login import PerforceLoginTray
 
 
@@ -92,12 +93,13 @@ class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
         })
         ws_tmpl = StringTemplate(settings["workspace"]["template"])
         ws_name = ws_tmpl.format_strict(tmpl_data)
+        username, password = get_local_login()
 
         return ConnectionInfo(
             host=settings["host_name"],
             port=settings["port"],
-            username="hardcode for now",
-            password="hardcode for now",  # that will come from tray login
+            username=username,
+            password=password,
             workspace_name=ws_name
         )
 

--- a/client/ayon_perforce/changes_viewer/control.py
+++ b/client/ayon_perforce/changes_viewer/control.py
@@ -9,7 +9,6 @@ from ayon_core.lib.events import QueuedEventSystem
 from ayon_core.pipeline import registered_host
 
 from ayon_perforce.backend.rest_stub import PerforceRestStub
-from ayon_perforce.lib import WorkspaceProfileContext
 
 if TYPE_CHECKING:
     from ayon_core.host import HostBase
@@ -37,17 +36,12 @@ class ChangesViewerController:
         self._perforce_addon: PerforceAddon = perforce_addon
         self.enabled = perforce_addon and perforce_addon.enabled
 
-        task_entity = launch_data.task_entity
-        workspace_profile_context = WorkspaceProfileContext(
-            folder_paths=launch_data.folder_path,
-            task_names=task_entity["name"],
-            task_types=task_entity["taskType"],
-        )
-
         self._conn_info: ConnectionInfo = (
             self._perforce_addon.get_connection_info(
                 project_name=launch_data.project_name,
-                context=workspace_profile_context
+                task_entity=launch_data.task_entity,
+                folder_entity=launch_data.folder_entity,
+                folder_path=launch_data.folder_path,
             ))
 
         self._event_system = self._create_event_system()

--- a/client/ayon_perforce/changes_viewer/control.py
+++ b/client/ayon_perforce/changes_viewer/control.py
@@ -85,7 +85,15 @@ class ChangesViewerController:
         """
         return PerforceRestStub.get_changes()
 
-    def sync_to(self, change_id: int):
+    def sync_to(self, change_id: int) -> None:
+        """Sync to specific changelist number.
+
+        Args:
+            change_id (int): Changelist number.
+
+        Raises:
+            RuntimeError: If Perforce connection information is not collected.
+        """
         if not self.enabled:
             return
 

--- a/client/ayon_perforce/launch_hooks/pre_load_sync_project.py
+++ b/client/ayon_perforce/launch_hooks/pre_load_sync_project.py
@@ -23,7 +23,6 @@ from ayon_perforce import is_perforce_enabled
 from ayon_perforce.addon import LaunchData
 from ayon_perforce.backend.rest_stub import PerforceRestStub
 from ayon_perforce.changes_viewer import ChangesWindows
-from ayon_perforce.lib import WorkspaceProfileContext
 
 if TYPE_CHECKING:
     from ayon_perforce.addon import ConnectionInfo, PerforceAddon
@@ -86,20 +85,18 @@ class SyncUnrealProject(PreLaunchHook):
             RuntimeError: If workspace or project file is not
 
         """
-        task_entity = launch_data.task_entity
-        workspace_profile_context = WorkspaceProfileContext(
-            folder_paths=launch_data.folder_path,
-            task_names=task_entity["name"],
-            task_types=task_entity["taskType"],
-        )
         conn_info: ConnectionInfo = perforce_addon.get_connection_info(
             project_name=launch_data.project_name,
+            task_entity=launch_data.task_entity,
+            folder_entity=launch_data.folder_entity,
+            folder_path=launch_data.folder_path,
             project_settings=launch_data.project_settings,
-            context=workspace_profile_context
         )
 
         if not conn_info or not conn_info.workspace_name:
             msg = "Cannot find workspace for this context."
+            # TODO: check with p4 whether ws exists or not
+            #       - just the ws_name isn't enough
             raise RuntimeError(msg)
 
         PerforceRestStub.login(**asdict(conn_info))

--- a/client/ayon_perforce/lib.py
+++ b/client/ayon_perforce/lib.py
@@ -1,9 +1,46 @@
+from os import environ
 from dataclasses import dataclass
+
+from ayon_core.lib import AYONSecureRegistry
 
 
 @dataclass
 class WorkspaceProfileContext:
     """Data that could be used in filtering workspace name."""
+
     folder_paths: str
     task_names: str
     task_types: str
+
+
+def get_local_login() -> None:
+    """Get the Perforce Login entry from the local registry."""
+    try:
+        reg = AYONSecureRegistry("perforce/username")
+        username = reg.get_item("value")
+        reg = AYONSecureRegistry("perforce/password")
+        password = reg.get_item("value")
+    except ValueError:
+        return (None, None)
+
+    return (username, password)
+
+
+def save_local_login(username: str, password: str) -> None:
+    """Save the Perforce Login entry from the local registry."""
+    reg = AYONSecureRegistry("perforce/username")
+    reg.set_item("value", username)
+    reg = AYONSecureRegistry("perforce/password")
+    reg.set_item("value", password)
+    environ["P4USER"] = username
+
+
+def clear_local_login() -> None:
+    """Clear the Perforce Login entry from the local registry."""
+    reg = AYONSecureRegistry("perforce/user")
+    if reg.get_item("value", None) is not None:
+        reg.delete_item("value")
+    reg = AYONSecureRegistry("perforce/pass")
+    if reg.get_item("value", None) is not None:
+        reg.delete_item("value")
+    environ["P4USER"] = ""

--- a/client/ayon_perforce/tray/login.py
+++ b/client/ayon_perforce/tray/login.py
@@ -41,15 +41,15 @@ class PerforceLoginTray:
         server_url = self.addon.get_server_url()
         if not server_url:
             server_url = "No Perforce Server set in AYON Settings."
-        self.p4_host_action = QtWidgets.QAction(f"Server: {server_url}")
-        self.p4_host_action.setDisabled(True)
+        self.host_action = QtWidgets.QAction(f"Server: {server_url}")
+        self.host_action.setDisabled(True)
 
         text = _get_username_action_text()
-        self.p4_username_action = QtWidgets.QAction(text)
-        self.p4_username_action.triggered.connect(self.show_p4_username_dialog)
+        self.username_action = QtWidgets.QAction(text)
+        self.username_action.triggered.connect(self.show_username_dialog)
 
-        self.p4_username_dialog = PerforceLoginDialog(self.addon)
-        self.p4_username_dialog.dialog_closed.connect(self.set_username_label)
+        self.username_dialog = PerforceLoginDialog(self.addon)
+        self.username_dialog.dialog_closed.connect(self.set_username_label)
 
     def tray_menu(self, tray_menu: QtWidgets.QMenu) -> None:
         """Add Perforce Submenu to AYON tray.
@@ -66,15 +66,15 @@ class PerforceLoginTray:
         p4_tray_menu.addAction(self.p4_username_action)
         tray_menu.addMenu(p4_tray_menu)
 
-    def show_p4_username_dialog(self) -> None:
+    def show_username_dialog(self) -> None:
         """Display the Perforce login dialog.
 
         Used to set a Shotgrid Username, that will then be used by any API call
         and to check that the user can access the Shotgrid API.
         """
-        self.p4_username_dialog.show()
-        self.p4_username_dialog.activateWindow()
-        self.p4_username_dialog.raise_()
+        self.username_dialog.show()
+        self.username_dialog.activateWindow()
+        self.username_dialog.raise_()
 
     def set_username_label(self) -> None:
         """Set the Username Label based on local login setting.
@@ -88,5 +88,5 @@ class PerforceLoginTray:
             os.environ["P4USER"] = username
         else:
             os.environ["P4USER"] = ""
-            self.show_p4_username_dialog()
-        self.p4_username_action.setText(text)
+            self.show_username_dialog()
+        self.username_action.setText(text)

--- a/client/ayon_perforce/tray/login.py
+++ b/client/ayon_perforce/tray/login.py
@@ -61,9 +61,9 @@ class PerforceLoginTray:
             tray_menu (QtWidgets.QMenu): The AYON Tray menu.
         """
         p4_tray_menu = QtWidgets.QMenu("Perforce", tray_menu)
-        p4_tray_menu.addAction(self.p4_host_action)
+        p4_tray_menu.addAction(self.host_action)
         p4_tray_menu.addSeparator()
-        p4_tray_menu.addAction(self.p4_username_action)
+        p4_tray_menu.addAction(self.username_action)
         tray_menu.addMenu(p4_tray_menu)
 
     def show_username_dialog(self) -> None:

--- a/client/ayon_perforce/tray/login.py
+++ b/client/ayon_perforce/tray/login.py
@@ -1,0 +1,78 @@
+"""Module for Perforce login tray functionality."""
+
+import os
+
+from qtpy import QtWidgets
+
+# from ayon_shotgrid.lib import credentials
+from ayon_perforce.tray.login_dialog import PerforceLoginDialog
+
+
+class PerforceLoginTray:
+    """Shotgrid menu entry for the AYON tray.
+
+    Displays the Shotgrid URL specified in the Server Addon Settings and
+    allows the person to set a username to be used with the API.
+
+    There's the option to check if said user has permissions to connect to the
+    API.
+    """
+
+    def __init__(self, addon):
+        self.addon = addon
+
+        # server_url = self.addon.get_sg_url()
+
+        # if not server_url:
+        #     server_url = "No Shotgrid Server set in AYON Settings."
+
+        self.p4_host_action = QtWidgets.QAction(f"Server: get from server settings")
+        self.p4_host_action.setDisabled(True)
+        self.p4_username_action = QtWidgets.QAction("")
+        self.p4_username_action.triggered.connect(self.show_p4_username_dialog)
+
+        self.p4_username_dialog = PerforceLoginDialog(self.addon)
+        self.p4_username_dialog.dialog_closed.connect(self.set_username_label)
+
+    def show_p4_username_dialog(self) -> None:
+        """Display the Shotgrid Username dialog.
+
+        Used to set a Shotgrid Username, that will then be used by any API call
+        and to check that the user can access the Shotgrid API.
+        """
+        self.p4_username_dialog.show()
+        self.p4_username_dialog.activateWindow()
+        self.p4_username_dialog.raise_()
+
+    def tray_menu(self, tray_menu):
+        """Add Shotgrid Submenu to AYON tray.
+
+        A non-actionable action displays the Shotgrid URL and the other
+        action allows the person to set and check their Shotgrid username.
+
+        Args:
+            tray_menu (QtWidgets.QMenu): The AYON Tray menu.
+        """
+        p4_tray_menu = QtWidgets.QMenu("Perforce", tray_menu)
+        p4_tray_menu.addAction(self.p4_host_action)
+        p4_tray_menu.addSeparator()
+        p4_tray_menu.addAction(self.p4_username_action)
+        tray_menu.addMenu(p4_tray_menu)
+
+    def set_username_label(self) -> None:
+        """Set the Username Label based on local login setting.
+
+        Depending on the login credentiasl we want to display one message or
+        another in the Shotgrid submenu action.
+        """
+        # sg_username, _ = credentials.get_local_login()  # TODO: use AYONSecureRegistry directly
+        p4_username = None
+        if p4_username:
+            self.p4_username_action.setText(
+                "Username: {} (Click to change)".format(p4_username)
+            )
+            os.environ["AYON_SG_USERNAME"] = p4_username
+        else:
+            self.p4_username_action.setText("Specify a Username...")
+            os.environ["P4USER"] = ""
+            self.show_p4_username_dialog()

--- a/client/ayon_perforce/tray/login.py
+++ b/client/ayon_perforce/tray/login.py
@@ -10,6 +10,20 @@ from ayon_perforce import lib as p4lib
 from ayon_perforce.tray.login_dialog import PerforceLoginDialog
 
 
+def _get_username_action_text() -> str:
+    """Get the text for the username action.
+
+    Returns:
+        str: The text used for the username action
+    """
+    username, _ = p4lib.get_local_login()
+    return (
+        f"Username: {username} (Click to change)"
+        if username
+        else "Specify a Username..."
+    )
+
+
 class PerforceLoginTray:
     """Shotgrid menu entry for the AYON tray.
 
@@ -27,11 +41,11 @@ class PerforceLoginTray:
         server_url = self.addon.get_server_url()
         if not server_url:
             server_url = "No Perforce Server set in AYON Settings."
-
         self.p4_host_action = QtWidgets.QAction(f"Server: {server_url}")
         self.p4_host_action.setDisabled(True)
 
-        self.p4_username_action = QtWidgets.QAction("")
+        text = _get_username_action_text()
+        self.p4_username_action = QtWidgets.QAction(text)
         self.p4_username_action.triggered.connect(self.show_p4_username_dialog)
 
         self.p4_username_dialog = PerforceLoginDialog(self.addon)
@@ -69,12 +83,10 @@ class PerforceLoginTray:
         another in the Perforce submenu action.
         """
         username, _ = p4lib.get_local_login()
-
+        text = _get_username_action_text()
         if username:
-            lbl = f"Username: {username} (Click to change)"
-            self.p4_username_action.setText(lbl)
             os.environ["P4USER"] = username
         else:
-            self.p4_username_action.setText("Specify a Username...")
             os.environ["P4USER"] = ""
             self.show_p4_username_dialog()
+        self.p4_username_action.setText(text)

--- a/client/ayon_perforce/tray/login.py
+++ b/client/ayon_perforce/tray/login.py
@@ -21,12 +21,11 @@ class PerforceLoginTray:
     def __init__(self, addon):
         self.addon = addon
 
-        # server_url = self.addon.get_sg_url()
+        server_url = self.addon.get_server_url()
+        if not server_url:
+            server_url = "No Perforce Server set in AYON Settings."
 
-        # if not server_url:
-        #     server_url = "No Shotgrid Server set in AYON Settings."
-
-        self.p4_host_action = QtWidgets.QAction(f"Server: get from server settings")
+        self.p4_host_action = QtWidgets.QAction(f"Server: {server_url}")
         self.p4_host_action.setDisabled(True)
         self.p4_username_action = QtWidgets.QAction("")
         self.p4_username_action.triggered.connect(self.show_p4_username_dialog)

--- a/client/ayon_perforce/tray/login_dialog.py
+++ b/client/ayon_perforce/tray/login_dialog.py
@@ -1,0 +1,151 @@
+import os
+
+# from ayon_shotgrid.lib import credentials
+
+from ayon_core import style
+from ayon_core import resources
+from qtpy import QtCore, QtWidgets, QtGui
+
+
+class PerforceLoginDialog(QtWidgets.QDialog):
+    """A QDialog that allows the person to set a Shotgrid Username.
+
+    It also allows them to test the username against the API.
+    """
+
+    dialog_closed = QtCore.Signal()
+
+    def __init__(self, addon, parent=None):
+        super(PerforceLoginDialog, self).__init__(parent)
+        self.addon = addon
+        # self.login_type = self.addon.get_client_login_type()
+
+        self.setWindowTitle("AYON - Perforce Login")
+        icon = QtGui.QIcon(resources.get_ayon_icon_filepath())
+        self.setWindowIcon(icon)
+
+        self.setWindowFlags(
+            QtCore.Qt.WindowCloseButtonHint
+            | QtCore.Qt.WindowMinimizeButtonHint
+        )
+
+        self.setStyleSheet(style.load_stylesheet())
+        self.setContentsMargins(2, 2, 2, 2)
+
+        self.setup_ui()
+
+    def closeEvent(self, event):
+        """Clear any message when closing the dialog."""
+        self.sg_connection_message.setText("")
+        self.dialog_closed.emit()
+        super(PerforceLoginDialog, self).closeEvent(event)
+
+    def setup_ui(self):
+        server_url = "10.10.10.161:1666"
+
+        if not server_url:
+            server_url = "No Shotgrid Server set in AYON Settings."
+
+        sg_server_url_label = QtWidgets.QLabel(
+            "Please provide the credentials to log in into the "
+            f"Shotgrid Server:\n{server_url}"
+        )
+
+        dialog_layout = QtWidgets.QVBoxLayout()
+        dialog_layout.addWidget(sg_server_url_label)
+
+        # sg_username, sg_password = credentials.get_local_login()
+        sg_username, sg_password = None, None
+
+        self.sg_username_input = QtWidgets.QLineEdit()
+
+        if sg_username:
+            self.sg_username_input.setText(sg_username)
+        else:
+            self.sg_username_input.setPlaceholderText("jane.doe@mycompany.com")
+        self.sg_password_input = QtWidgets.QLineEdit()
+        self.sg_password_input.setEchoMode(QtWidgets.QLineEdit.Password)
+
+        if sg_password:
+            self.sg_password_input.setText(sg_password)
+        else:
+            self.sg_password_input.setPlaceholderText("password1234")
+
+        dialog_layout.addWidget(QtWidgets.QLabel("Perforce Username:"))
+        dialog_layout.addWidget(self.sg_username_input)
+
+        # if self.login_type == "tray_pass":
+        dialog_layout.addWidget(QtWidgets.QLabel("Perforce Password:"))
+        dialog_layout.addWidget(self.sg_password_input)
+
+        self.sg_check_login_button = QtWidgets.QPushButton(
+            "Login into Perforce..."
+        )
+        self.sg_check_login_button.clicked.connect(self.check_sg_credentials)
+        self.sg_connection_message = QtWidgets.QLabel("")
+
+        dialog_layout.addWidget(self.sg_check_login_button)
+        dialog_layout.addWidget(self.sg_connection_message)
+
+        self.setLayout(dialog_layout)
+
+    def set_local_login(self):
+        """Change Username label, save in local registry and set env var."""
+        sg_username = self.sg_username_input.text()
+        sg_password = self.sg_password_input.text()
+
+        if self.login_type == "tray_pass":
+            if sg_username and sg_password:
+                credentials.save_local_login(sg_username, sg_password)
+                os.environ["AYON_SG_USERNAME"] = sg_username
+            else:
+                credentials.clear_local_login()
+                os.environ["AYON_SG_USERNAME"] = ""
+
+        elif self.login_type == "tray_api_key":
+            if sg_username:
+                credentials.save_local_login(sg_username, None)
+                os.environ["AYON_SG_USERNAME"] = sg_username
+            else:
+                credentials.clear_local_login()
+                os.environ["AYON_SG_USERNAME"] = ""
+
+    def check_sg_credentials(self):
+        """Check if the provided username can login via the API."""
+        sg_username = self.sg_username_input.text()
+        sg_password = self.sg_password_input.text()
+
+        kwargs = {
+            "shotgrid_url": self.addon.get_sg_url(),
+        }
+
+        if self.login_type == "tray_pass":
+            if not sg_username or not sg_password:
+                self.sg_connection_message.setText(
+                    "Please provide a valid username and password."
+                )
+                return
+            kwargs.update({"username": sg_username, "password": sg_password})
+
+        elif self.login_type == "tray_api_key":
+            if not sg_username:
+                self.sg_connection_message.setText(
+                    "Please provide a valid username."
+                )
+                return
+            kwargs.update({
+                "username": sg_username,
+                "api_key": self.addon.get_sg_api_key(),
+                "script_name": self.addon.get_sg_script_name(),
+            })
+
+        login_result, login_message = credentials.check_user_permissions(
+            **kwargs
+        )
+
+        self.set_local_login()
+
+        if login_result:
+            self.close()
+        else:
+            self.sg_connection_message.setText(login_message)

--- a/client/ayon_perforce/tray/login_dialog.py
+++ b/client/ayon_perforce/tray/login_dialog.py
@@ -107,3 +107,4 @@ class PerforceLoginDialog(QtWidgets.QDialog):
             p4lib.save_local_login(username, password)
         else:
             p4lib.clear_local_login()
+        self.close()

--- a/client/ayon_perforce/version.py
+++ b/client/ayon_perforce/version.py
@@ -1,2 +1,3 @@
+# -*- coding: utf-8 -*-
 """Package declaring AYON addon 'perforce' version."""
 __version__ = "0.0.1+dev.1"

--- a/client/ayon_perforce/version.py
+++ b/client/ayon_perforce/version.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 """Package declaring AYON addon 'perforce' version."""
 __version__ = "0.0.1+dev.1"

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,13 +1,10 @@
-#from typing import Type
-
 from ayon_server.addons import BaseServerAddon
 
-from .settings import VersionControlSettings, DEFAULT_VALUES
+from .settings import PerforceSettings, DEFAULT_VALUES
 
 
 class PerforceAddon(BaseServerAddon):
-    #settings_model: Type[VersionControlSettings] = VersionControlSettings
-    settings_model = VersionControlSettings
+    settings_model = PerforceSettings
 
 
     async def get_default_settings(self):

--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -1,10 +1,10 @@
 from .main import (
-    VersionControlSettings,
+    PerforceSettings,
     DEFAULT_VALUES
 )
 
 
 __all__ = (
-    "VersionControlSettings",
+    "PerforceSettings",
     "DEFAULT_VALUES",
 )

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -102,7 +102,7 @@ class LocalSubmodel(BaseSettingsModel):
     )
 
 
-class VersionControlSettings(BaseSettingsModel):
+class PerforceSettings(BaseSettingsModel):
     """Version Control Project Settings."""
 
     enabled: bool = Field(default=False)

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -56,11 +56,37 @@ class PublishPluginsModel(BaseSettingsModel):
         )
     )
 
+class StreamProfile(BaseSettingsModel):
+    """Stream profile settings."""
+    template: str = Field(
+        default="",
+        title="Stream Name Template"
+    )
+    task_types: list[str] = Field(
+        enum_resolver=task_types_enum,
+        title="Task Type"
+    )
+
+
+class StreamModel(BaseSettingsModel):
+    """Stream settings."""
+    enabled: bool = Field(default=False)
+    profiles: list[StreamProfile] = Field(
+        default_factory=list,
+        title="Stream Profiles" 
+    )
 
 class WorkspaceModel(BaseSettingsModel):
     """Workspace settings."""
 
-    template: bool = Field(default=False)
+    depot: str = Field(
+        "",
+        title="Depot Name Template"
+    )
+    template: str = Field(
+        "",
+        title="Workspace Name Template"
+    )
 
 
 class PerforceSettings(BaseSettingsModel):
@@ -75,9 +101,15 @@ class PerforceSettings(BaseSettingsModel):
         1666,
         title="Port"
     )
-    workspace_template: str = Field(
-        "",
-        title="Workspace Name Template"
+    
+    workspace: WorkspaceModel = Field(
+        default_factory=WorkspaceModel,
+        title="Workspace Settings"
+    )
+    stream: StreamModel = Field(
+        default_factory=StreamModel,
+        title="Stream Settings",
+        description="WIP: enable to use streams in p4"
     )
     publish: PublishPluginsModel = Field(
         default_factory=PublishPluginsModel,

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -46,31 +46,6 @@ class CollectPerforceControlModel(BaseSettingsModel):
     )
 
 
-class WorkspaceProfileModel(BaseSettingsModel):
-    _layout = "expanded"
-    folder_paths: list[str] = SettingsField(
-        default_factory=list,
-        title="Folder paths",
-        scope=["site"]
-    )
-    task_types: list[str] = SettingsField(
-        default_factory=list,
-        title="Task types",
-        enum_resolver=task_types_enum,
-        scope=["site"]
-    )
-    task_names: list[str] = SettingsField(
-        default_factory=list,
-        title="Task names",
-        scope=["site"]
-    )
-    workspace_name: str = Field(
-        "",
-        title="My Workspace Name",
-        scope=["site"]
-    )
-
-
 class PublishPluginsModel(BaseSettingsModel):
     CollectPerforceControl: CollectPerforceControlModel = Field(
         default_factory=CollectPerforceControlModel,
@@ -82,51 +57,31 @@ class PublishPluginsModel(BaseSettingsModel):
     )
 
 
+class WorkspaceModel(BaseSettingsModel):
+    """Workspace settings."""
 
-class LocalSubmodel(BaseSettingsModel):
-    """Provide artist based values"""
-
-    username: str = Field(
-        "",
-        title="Username",
-        scope=["site"]
-    )
-    password: str = Field(
-        "",
-        title="Password",
-        scope=["site"]
-    )
-    workspace_profiles: list[WorkspaceProfileModel] = SettingsField(
-        default_factory=list,
-        scope=["site"]
-    )
+    template: bool = Field(default=False)
 
 
 class PerforceSettings(BaseSettingsModel):
     """Version Control Project Settings."""
 
     enabled: bool = Field(default=False)
-
     host_name: str = Field(
         "perforce",
         title="Host name"
     )
-
     port: int = Field(
         1666,
         title="Port"
     )
-
+    workspace_template: str = Field(
+        "",
+        title="Workspace Name Template"
+    )
     publish: PublishPluginsModel = Field(
         default_factory=PublishPluginsModel,
         title="Publish Plugins",
-    )
-
-    local_setting: LocalSubmodel = Field(
-        default_factory=LocalSubmodel,
-        title="Local setting",
-        scope=["site"],
-        description="This setting is only applicable for artist's site",
     )
 
 


### PR DESCRIPTION
## Changelog Description
- adresses https://github.com/ynput/ayon-perforce/issues/5
- server settings mockup
![image](https://github.com/user-attachments/assets/e2c4001a-6f1b-4b81-89b8-77e5599f26cb)
  - adds `{workstation}` token to templating
    - retrieved from `ayon_core.lib.ayon_info.get_workstation_info()`
  - unsure about "Depot Name Template", workspace implies depot
    - could be used for workspace creation if none is found based on depot and workspace templates
      - useful for farm rendering
- implements login from AYONLauncher tray

## Additional review information
- doesn't check if login is valid in tray action
  - would do that in the cli abstraction in a different pr

### ToDo
- [ ] fix NameError `pywintypes` in ue by pip installing `pywin32` in its prelaunch hook