### PR TITLE
Limit Perforce Pyblish plugins to Unreal only

### DIFF
--- a/client/ayon_perforce/plugins/publish/collect_latest_changelist.py
+++ b/client/ayon_perforce/plugins/publish/collect_latest_changelist.py
@@ -28,6 +28,9 @@ class CollectLatestChangeList(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder + 0.4995
     targets: ClassVar[list[str]] = ["local"]
     families: ClassVar[list[str]] = ["changelist_metadata"]
+    # TODO (antirotor): https://github.com/ynput/ayon-perforce/issues/15
+    #    because of this issue, limit this plugin to Unreal hosts only
+    hosts: ClassVar[list[str]] = ["unreal"]
     log: logging.Logger
 
     def process(self, instance: pyblish.api.Instance) -> None:

--- a/client/ayon_perforce/plugins/publish/collect_perforce_control.py
+++ b/client/ayon_perforce/plugins/publish/collect_perforce_control.py
@@ -28,6 +28,9 @@ class CollectPerforceControl(pyblish.api.InstancePlugin):
     label = "Collect Perforce Submission Info"
     order = pyblish.api.CollectorOrder + 0.4992
     targets: ClassVar[list[str]] = ["local"]
+    # TODO (antirotor): https://github.com/ynput/ayon-perforce/issues/15
+    #    because of this issue, limit this plugin to Unreal hosts only
+    hosts: ClassVar[list[str]] = ["unreal"]
 
     settings_category = "perforce"
 

--- a/client/ayon_perforce/plugins/publish/collect_perforce_login.py
+++ b/client/ayon_perforce/plugins/publish/collect_perforce_login.py
@@ -32,6 +32,10 @@ class CollectPerforceLogin(pyblish.api.ContextPlugin):
     label = "Collect Perforce Connection Info"
     order = pyblish.api.CollectorOrder + 0.4990
     targets: ClassVar = ["local"]
+    # TODO (antirotor): limit this plugin to Unreal hosts only, until issues
+    #   with pywin32are resolved.
+    #   https://github.com/ynput/ayon-perforce/issues/15
+    hosts: ClassVar[list[str]] = ["unreal"]
     log: Logger
 
     def process(self, context: pyblish.api.Context) -> None:


### PR DESCRIPTION
## Changelog Description
Limiting perforce related pyblish plugins to Unreal host only, until #15 is resolved at least.

## Additional review information
DCC with different Python version that is in *ayon-launcher* won't be able to use pywin32 that comes with it because it is binary dependency. Building it for every supported host isn't really an option. See linked issue for more details.

## Testing notes:
Run any DCC like Maya 2025 with different Python version and *ayon-perforce* enabled. Nothing should crash and you shouldn't see perforce related collectors.
