### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_perforce/plugins/create/unreal/changelist_metadata.py
+++ b/client/ayon_perforce/plugins/create/unreal/changelist_metadata.py
@@ -20,6 +20,7 @@ class UnrealPublishCommit(UnrealBaseAutoCreator):
     """
     identifier = "io.ayon.creators.unreal.changelist_metadata"
     product_type = "changelist_metadata"
+    product_base_type = "changelist_metadata"
     label = "Publish Changelist Metadata"
     host_name = "unreal"
 


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to existing creators. In this stage, it only mimics the product types. This has to be done in all DCC before further changes can be done in https://github.com/ynput/ayon-core to finalize the support.

## Additional review information
Additional PRs should check/address the usage of `product_type` as family - plugins shouldn't rely on having product type as family because if/when this is customized, workflow could stop work or behave unpredicable.

## Testing notes:
Everything should work as before.