### PR TITLE
Chore: Arguments cleanup

### DIFF
--- a/client/ayon_perforce/addon.py
+++ b/client/ayon_perforce/addon.py
@@ -57,16 +57,16 @@ class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
     def get_connection_info(
         self,
         project_name: str,
-        task_entity: dict,
         folder_entity: dict,
+        task_entity: dict,
         project_settings: Optional[dict] = None,
     ) -> ConnectionInfo:
         """Get connection information for Perforce.
 
         Args:
             project_name (str): Name of the project.
-            task_entity (dict): Task entity.
             folder_entity (dict): Folder entity.
+            task_entity (dict): Task entity.
             project_settings (Optional[dict]): Project settings.
 
         Returns:

--- a/client/ayon_perforce/addon.py
+++ b/client/ayon_perforce/addon.py
@@ -36,7 +36,6 @@ class LaunchData:
     folder_entity: dict[str, Any]
     task_entity: dict[str, Any]
     project_settings: dict[str, Any]
-    folder_path: str
 
 
 class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
@@ -60,7 +59,6 @@ class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
         project_name: str,
         task_entity: dict,
         folder_entity: dict,
-        folder_path: str,
         project_settings: Optional[dict] = None,
     ) -> ConnectionInfo:
         """Get connection information for Perforce.
@@ -69,7 +67,6 @@ class PerforceAddon(AYONAddon, ITrayService, IPluginPaths):
             project_name (str): Name of the project.
             task_entity (dict): Task entity.
             folder_entity (dict): Folder entity.
-            folder_path (str): Folder path.
             project_settings (Optional[dict]): Project settings.
 
         Returns:

--- a/client/ayon_perforce/changes_viewer/control.py
+++ b/client/ayon_perforce/changes_viewer/control.py
@@ -39,8 +39,8 @@ class ChangesViewerController:
         self._conn_info: ConnectionInfo = (
             self._perforce_addon.get_connection_info(
                 project_name=launch_data.project_name,
-                task_entity=launch_data.task_entity,
                 folder_entity=launch_data.folder_entity,
+                task_entity=launch_data.task_entity,
             ))
 
         self._event_system = self._create_event_system()

--- a/client/ayon_perforce/changes_viewer/control.py
+++ b/client/ayon_perforce/changes_viewer/control.py
@@ -41,7 +41,6 @@ class ChangesViewerController:
                 project_name=launch_data.project_name,
                 task_entity=launch_data.task_entity,
                 folder_entity=launch_data.folder_entity,
-                folder_path=launch_data.folder_path,
             ))
 
         self._event_system = self._create_event_system()

--- a/client/ayon_perforce/launch_hooks/pre_load_sync_project.py
+++ b/client/ayon_perforce/launch_hooks/pre_load_sync_project.py
@@ -55,7 +55,6 @@ class SyncUnrealProject(PreLaunchHook):
             folder_entity=self.data["folder_entity"],
             task_entity=self.data["task_entity"],
             project_settings=self.data["project_settings"],
-            folder_path=self.data["folder_path"],
         )
 
         self.data["last_workfile_path"] = self._get_unreal_project_path(
@@ -89,7 +88,6 @@ class SyncUnrealProject(PreLaunchHook):
             project_name=launch_data.project_name,
             task_entity=launch_data.task_entity,
             folder_entity=launch_data.folder_entity,
-            folder_path=launch_data.folder_path,
             project_settings=launch_data.project_settings,
         )
 

--- a/client/ayon_perforce/launch_hooks/pre_load_sync_project.py
+++ b/client/ayon_perforce/launch_hooks/pre_load_sync_project.py
@@ -86,8 +86,8 @@ class SyncUnrealProject(PreLaunchHook):
         """
         conn_info: ConnectionInfo = perforce_addon.get_connection_info(
             project_name=launch_data.project_name,
-            task_entity=launch_data.task_entity,
             folder_entity=launch_data.folder_entity,
+            task_entity=launch_data.task_entity,
             project_settings=launch_data.project_settings,
         )
 

--- a/client/ayon_perforce/plugins/publish/collect_perforce_login.py
+++ b/client/ayon_perforce/plugins/publish/collect_perforce_login.py
@@ -95,7 +95,6 @@ class CollectPerforceLogin(pyblish.api.ContextPlugin):
             "project_name": project_name,
             "task_entity": context.data.get("taskEntity"),
             "folder_entity": context.data.get("folderEntity"),
-            "folder_path": context.data.get("folderPath"),
             "project_settings": project_settings,
         }
         if not all(conn_info_payload.values()):

--- a/client/ayon_perforce/plugins/publish/collect_perforce_login.py
+++ b/client/ayon_perforce/plugins/publish/collect_perforce_login.py
@@ -93,8 +93,8 @@ class CollectPerforceLogin(pyblish.api.ContextPlugin):
         """
         conn_info_payload = {
             "project_name": project_name,
-            "task_entity": context.data.get("taskEntity"),
             "folder_entity": context.data.get("folderEntity"),
+            "task_entity": context.data.get("taskEntity"),
             "project_settings": project_settings,
         }
         if not all(conn_info_payload.values()):


### PR DESCRIPTION
## Changelog Description
Removed `folder_path` from arguments in `get_connection_info` and swap order of `folder_entity` and `task_entity` arguments.

## Additional review information
The argument `folder_path` is not used, also `folder_entity` is passed along so all the places should have access to folder path using the folder entity. Swap of `folder_entity` and `task_entity` is purely because of the hierarchy order project -> folder -> task.

I don't know if `LaunchData` or `get_connection_info` are used in other addons and change of the arguments might break api backwards compatibility.

## Testing notes:
1. Validate code changes.
